### PR TITLE
Added zfsadm shrink option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,13 @@
-Installation:  Copy the EXEC members into a library in your SYSPROC
-               or SYSEXEC allocation.
-               Copy the PANELS members into a library in your ISPPLIB
-               allocation.
+## Installation
+1. Copy the EXEC members into a library in your SYSPROC or SYSEXEC allocation.
+2. Copy the PANELS members into a library in your ISPPLIB allocation.
 
-Dependencies:
-  - This ISPF dialog utilizes the STEMEDIT utility which can be found
-    on the CBTTape FILE 183.
-  - Some elements of the dialog require the user to have SuperUser
-    capability.
-  - the zLSOF option on the menu requires access to SYS1.SBPXEXEC where
-    IBM ships this exec
+## Dependencies
+ - This ISPF dialog utilizes the STEMEDIT utility which can be found on the [CBTTape](https://www.cbttape.org/) FILE 183.
+ - Some elements of the dialog require the user to have SuperUser capability.
+ - the zLSOF option on the menu requires access to SYS1.SBPXEXEC where IBM ships this exec.
 
-Overview:
-
+## Overview
 zFSTools is an ISPF dialog that combines home grown and IBM dialogs to
 assist and simplify the management of zFS datasets. With this dialog you
 can backup a zFS dataset to a unloaded sequential dataset, restore a zFS
@@ -20,6 +15,8 @@ dataset from a backup, allocate a new zFS, grow the size of a zFS, access
 many of the zfsadm functions (grow is one of them), mount and unmount
 filesystems, and even rename a zFS dataset. All with comparitive ease thanks
 to the ISPF menus and panels.
+
+![image](https://user-images.githubusercontent.com/24498661/180071582-f2e127da-629c-4048-b693-e604a5d01a7f.png)
 
 Some of the functions require that the user have the ability to become
 a SuperUser and if you have that ability then those functions (e.g. mount,
@@ -37,55 +34,35 @@ datasets (exec and panels) and then install just the ZFSTOOLS exec into
 an allocated library in your SYSPROC or SYSEXEC concatenation.
 
 Some of the REXX exec's included are:
-
-   ZFSADM   - perfrom several of the zfsadm functions
-
-   ZFSALLOC - to allocate and format a new zFS (as a type 1.5)
-   ZFSBACK  - to backup a zFS to a sequential dataset
-              - uses IDCAMS REPRO
-              - make backup to a gdg
-              - Note that if the zFS to be backed up is mounted then
-                the code, using the sysdsn() function, gets a dataset
-                not found result. Strange but it does prevent an
-                attempt to backup an active zFS.
-
-   ZFSCOPY  - Generate ADRDSSU JCL to copy a zFS
-
- * ZFSGROW  - increase the size of a mounted zFS
-
-   ZFSIBM   - exec to access some of the IBM zFS dialogs
-            - Mount Table by File System
-            - Mount Table by Mount Point
-            * not supported prior to z/OS 2.2
-
-   ZFSMENU  - Simple exec to display the ZFSTools Menu Panel
-
-   ZFSMNT   - Mount a file system using the IBM Mount dialog
-            - if z/OS 2.1 then use custom dialog
-
-   ZFSRENAM - rename the zFS base and data datasets
-
-   ZFSREST  - to restore a zFS unloaded dataset
-            - uses IDCAMS REPRO
-            - can create a new zFS
-            - can delete a current zFS before allocating a new
-              zFS and reloading
-            - can restore from a gdg
-
-   ZFSSIZER - exec to prompt to size a zFS from a directory or by MB's
-
-   ZFSTOOLS - exec to altlib and libdef for this application if you
-              don't install in ispf allocated libraries
-
-   ZFSUMNT  - UnMount using the IBM Mount Table by File System
-              - if z/OS 2.1 then use custom dialog
-
-   ZFSUSE   - Display information about zFS usage
-
-   * - these functions require SU authority
-
-Acknowledgements:
-   - Ed Jaffe for how to use bpxwunix
-   - Paul from IBM z/OS USS Shell and Utilities for how to set
-     SuperUser mode using syscall.
-   - Peter Giles for several usability updates
+* ZFSADM   - Perform several of the zfsadm functions
+* ZFSALLOC - To allocate and format a new zFS (as a type 1.5)
+* ZFSBACK  - To backup a zFS to a sequential dataset
+  * uses IDCAMS REPRO
+  * make backup to a gdg
+  * Note that if the zFS to be backed up is mounted then the code, using the sysdsn() function, gets a dataset not found result. Strange but it does prevent an attempt to backup an active zFS.
+* ZFSCOPY  - Generate ADRDSSU JCL to copy a zFS
+* ZFSGROW  - Increase the size of a mounted zFS (requires SU authority)
+* ZFSIBM   - Exec to access some of the IBM zFS dialogs
+  * Mount Table by File System
+  * Mount Table by Mount Point
+    * not supported prior to z/OS 2.2
+* ZFSMENU  - Simple exec to display the ZFSTools Menu Panel
+* ZFSMNT   - Mount a file system using the IBM Mount dialog
+  * If z/OS 2.1 then use custom dialog
+* ZFSRENAM - Rename the zFS base and data datasets
+* ZFSREST  - To restore a zFS unloaded dataset
+  * uses IDCAMS REPRO
+  * can create a new zFS
+  * can delete a current zFS before allocating a new zFS and reloading
+  * can restore from a gdg
+* ZFSSHRK  - Decreases the size of a mounted zFS
+* ZFSSIZER - Exec to prompt to size a zFS from a directory or by MB's
+* ZFSTOOLS - Exec to altlib and libdef for this application if you don't install in ISPF allocated libraries
+* ZFSUMNT  - UnMount using the IBM Mount Table by File System
+  * If z/OS 2.1 then use custom dialog
+* ZFSUSE   - Display information about zFS usage
+   
+## Acknowledgements
+- Ed Jaffe for how to use bpxwunix
+- Paul from IBM z/OS USS Shell and Utilities for how to set SuperUser mode using syscall
+- Peter Giles for several usability updates

--- a/ZFSTOOLS.EXEC/ZFSSHRK
+++ b/ZFSTOOLS.EXEC/ZFSSHRK
@@ -1,0 +1,63 @@
+/* --------------------  rexx procedure  -------------------- *  
+ * Name:      zfsshrk                                         *  
+ *                                                            *  
+ * Function:  Shrink an existing zFS dataset                  *  
+ *                                                            *  
+ * Syntax:    %zfsshrk                                        *  
+ *                                                            *  
+ * Author:    Lionel B. Dyck                                  *  
+ *                                                            *  
+ * Notes:     This function requires the user have            *  
+ *            UPDATE access to the zFS data set AND that the  *  
+ *            zFS be mounted.                                 *  
+ *                                                            *  
+ * History:                                                   *  
+ *            2022-07-20 - Creation                           *  
+ *                                                            *  
+ * ---------------------------------------------------------- */ 
+                                                                 
+ Address ISPExec                                                 
+ do forever                                                      
+    "Display Panel(zfsshrk)"                                     
+    if rc > 4 then exit 0                                        
+    call do_it                                                   
+    Address ISPExec                                              
+    end                                                          
+                                                                 
+Do_It:                                                           
+/* ------------------------------------ *                        
+ * Verify that the requested zFS exists *                        
+ * ------------------------------------ */                       
+ checkdsn = sysdsn(zfsdsn)                                       
+ if checkdsn \= "OK" & checkdsn \= "UNAVAILABLE DATASET" then do 
+    zedsmsg = ''                                                 
+    zedlmsg = 'Error:' zfsdsn "does not exist."                  
+    "Setmsg msg(isrz001)"                                        
+    return                                                       
+    end  */                                                      
+                                                                 
+ Address TSO                                                     
+ option = 'shrink -aggregate' zfsdsn '-size' size                
+ address syscall 'geteuid'                                       
+ myeuid=retval                                                   
+ Address syscall "seteuid 0"                                     
+ rc = bpxwunix("zfsadm" option,,stdout.,stderr.)                 
+ rc = syscalls("OFF")                                            
+ Address syscall "seteuid" myeuid                                
+ Address ISPExec 'vget (zfsview)'                                
+ if zfsview = '' then zfsview = 'Browse'                         
+    CALL stemview zfsview,'stdout.',,,"zfsadm" option            
+ if stderr.0 > 0 then do                                         
+    do i = 1 to stderr.0                                         
+       stem.i = stderr.i                                         
+       end                                                       
+    i = stderr.0 + 1                                             
+    stem.i = 'The error may be because the zFS is NOT mounted.'  
+    i = i + 1                                                    
+    stem.i = 'Verify that it is mounted and try again. Otherwise'
+    i = i + 1                                            
+    stem.i = 'look up the error code and correct.'       
+    stem.0 = i                                           
+    CALL stemview zfsview,'stem.',,,"zfsadm error" option
+    end                                                  
+ Return                                                  

--- a/ZFSTOOLS.PANELS/ZFSADM
+++ b/ZFSTOOLS.PANELS/ZFSADM
@@ -8,16 +8,16 @@
 %Option ===>_zcmd
 %
 %  1`aggrinfo       +Obtain information on an attached aggregate
-%  2`configquery    +query configuration settings for the zFS kernel
+%  2`configquery    +Query configuration settings for the zFS kernel
 %  3`fsinfo  !**    +Obtain file system information
 %  4`grow           +Grow a zFS (requires SuperUser)
-%  5`help           +get help on commands
-%  6`level          +display service level
-%  7`lsaggr         +list aggregates
-%  8`lsfs           +list filesystem information
-%  9`lssys          +list systems
-%  10`shrink  !***   +Shrink a zFS
-%  11`query          +query menu
+%  5`help           +Get help on commands
+%  6`level          +Display service level
+%  7`lsaggr         +List aggregates
+%  8`lsfs           +List filesystem information
+%  9`lssys          +List systems
+% 10`shrink  !***   +Shrink a zFS
+% 11`query          +Query menu
  +
   !**`z/OS 2.2 or newer, currently &zos390rl
  !***`z/OS 2.3 or newer, currently &zos390rl

--- a/ZFSTOOLS.PANELS/ZFSADM
+++ b/ZFSTOOLS.PANELS/ZFSADM
@@ -1,5 +1,5 @@
 )Attr Default(%+_)
-   $ type( input) intens(high) caps(on ) just(left )
+   $ type(input) intens(high) caps(on) just(left)
    ` type(text) intens(high) color(red)
    ! type(text) intens(high) color(yellow)
    ~ type(text) intens(high) color(turq)  hilite(reverse)
@@ -16,9 +16,11 @@
 %  7`lsaggr         +list aggregates
 %  8`lsfs           +list filesystem information
 %  9`lssys          +list systems
-% 10`query          +query menu
+%  10`shrink  !***   +Shrink a zFS
+%  11`query          +query menu
  +
- !**`z/OS 2.2 or newer, currently &zos390rl
+  !**`z/OS 2.2 or newer, currently &zos390rl
+ !***`z/OS 2.3 or newer, currently &zos390rl
  +
 %  Browse or View Results:$zfsview +Browse or View
  +
@@ -31,7 +33,7 @@
 &zfsview = trans(trunc(&zfsview,1) B,Browse V,View *,*)
 ver (&zfsview,nb,list,Browse,View)
 &ZSEL = TRANS (TRUNC (&ZCMD,'.')
-         1,'CMD(%zfsadm aggrinfo -long    )'
+         1,'CMD(%zfsadm aggrinfo -long   )'
          2,'CMD(%zfsadm configquery -all )'
          3,'CMD(%zfsadm fsinfo -all  )'
          4,'CMD(%zfsgrow)'
@@ -40,7 +42,8 @@ ver (&zfsview,nb,list,Browse,View)
          7,'CMD(%zfsadm lsaggr       )'
          8,'CMD(%zfsadm lsfs         )'
          9,'CMD(%zfsadm lssys        )'
-        10,'Panel(zfsquery)'
+        10,'CMD(%zfsshrk             )'
+        11,'Panel(zfsquery)'
          ' ',' '
          *,'?' )
 )End

--- a/ZFSTOOLS.PANELS/ZFSSHRK
+++ b/ZFSTOOLS.PANELS/ZFSSHRK
@@ -8,10 +8,10 @@
 %
 + zFS Dataset:!zfsdsn                                        +
 +
-+ Size:!size    +in Kilobytes after the shrink operation
++ Size:!size      +in Kilobytes after the shrink operation
 +
-% Notes:        +1. The zFS%must+be mounted for shrink to work
-+                2. You%must+have UPDATE authority to the VSAM linear data set
+% Notes:          +1. The zFS%must+be mounted for shrink to work
++                  2. You%must+have UPDATE authority to the VSAM linear data set
 +
 )Init
  .cursor = zfsdsn

--- a/ZFSTOOLS.PANELS/ZFSSHRK
+++ b/ZFSTOOLS.PANELS/ZFSSHRK
@@ -1,0 +1,21 @@
+)Attr Default(%+_)
+   ! type(input) intens(high) caps(on) just(left) Pad('_')
+   ~ type(text) intens(high) color(turq)  hilite(reverse)
+   ` type(text) intens(high) color(red)
+)Body  Expand(\\)
+%-\-\-~zFS Shrink%-\-\-
+%Command ===>_zcmd
+%
++ zFS Dataset:!zfsdsn                                        +
++
++ Size:!size    +in Kilobytes after the shrink operation
++
+% Notes:        +1. The zFS%must+be mounted for shrink to work
++                2. You%must+have UPDATE authority to the VSAM linear data set
++
+)Init
+ .cursor = zfsdsn
+)Proc
+  ver (&zfsdsn,nb,dsname)
+  ver (&size,nb,num)
+)End


### PR DESCRIPTION
I've added an additional option for zfsadm shrink support, on the zfsadm panel.

- New zfsshrk exec (borrowed zfsgrow exec and modified)
- New zfsshrk panel (borrowed zfsgrow panel and modified)
- Updated zfsadm exec

zfsadm shrink became available in z/OS v2r3, and allows zFS filesystems to be dynamically reduced in size, without needing to be unmounted.